### PR TITLE
export ignore attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.tmp export-ignore
+*.old export-ignore
+tmp export-ignore
+hold export-ignore
+.gitignore export-ignore
+.gitattributes export-ignore
+


### PR DESCRIPTION
this will prevent the hold folder from shipping with releases, as well as any files ending in .tmp or .old